### PR TITLE
remove injectcors options from hyperproxy services

### DIFF
--- a/compose/etc/config/gateway.yaml
+++ b/compose/etc/config/gateway.yaml
@@ -157,13 +157,11 @@ services:
     port: 8000
     path: /summary
     preservePath: true
-    injectCors: true
   - name: world.concrnt.hyperproxy.image
     host: hyperproxy
     port: 8000
     path: /image
     preservePath: true
-    injectCors: true
   - name: world.concrnt.mediaserver
     host: mediaserver
     port: 8000


### PR DESCRIPTION
hyperproxyがv0.1.0からcors設定の注入が不要になった(むしろimageに関しては今までcorsヘッダーが重複していたことが発覚した)ので該当設定を削除しました 🙇 